### PR TITLE
style: move the Abilities to its own column

### DIFF
--- a/tui/final_view.py
+++ b/tui/final_view.py
@@ -54,28 +54,28 @@ class FinalView:
 
             # --- [Column 2: ABILITIES] ---
             y_c2 = start_draw_y
-            self.stdscr.addstr(y_c2, col2_x, f"{theme.SYM_HEADER_L}ABILITIES{theme.SYM_HEADER_R}"[:col_width], theme.CLR_ACCENT()); y_c2 += 1
+            self.stdscr.addstr(y_c2, col2_x + 2, f"{theme.SYM_HEADER_L}ABILITIES{theme.SYM_HEADER_R}"[:col_width - 2], theme.CLR_ACCENT()); y_c2 += 1
             for n, d in [(n, d) for n, d in self.character.abilities.items() if d['new'] > 0]:
                 if y_c2 >= max_draw_y: break
-                self._display_trait(y_c2, col2_x, n, d, col_width); y_c2 += 1
+                self._display_trait(y_c2, col2_x + 2, n, d, col_width - 2); y_c2 += 1
 
             # --- [Column 3: EVERYTHING ELSE] ---
             y_c3 = start_draw_y
             for cat in ["disciplines", "backgrounds"]:
                 if getattr(self.character, cat) and y_c3 < max_draw_y:
-                    self.stdscr.addstr(y_c3, col3_x, f"{theme.SYM_HEADER_L}{cat.upper()}{theme.SYM_HEADER_R}"[:col_width], theme.CLR_ACCENT()); y_c3 += 1
+                    self.stdscr.addstr(y_c3, col3_x + 2, f"{theme.SYM_HEADER_L}{cat.upper()}{theme.SYM_HEADER_R}"[:col_width - 2], theme.CLR_ACCENT()); y_c3 += 1
                     for n, d in getattr(self.character, cat).items():
                         if y_c3 >= max_draw_y: break
-                        self._display_trait(y_c3, col3_x, n, d, col_width); y_c3 += 1
+                        self._display_trait(y_c3, col3_x + 2, n, d, col_width - 2); y_c3 += 1
                     y_c3 += 1
             
             if y_c3 < max_draw_y:
-                self.stdscr.addstr(y_c3, col3_x, f"{theme.SYM_HEADER_L}VIRTUES{theme.SYM_HEADER_R}"[:col_width], theme.CLR_ACCENT()); y_c3 += 1
+                self.stdscr.addstr(y_c3, col3_x + 2, f"{theme.SYM_HEADER_L}VIRTUES{theme.SYM_HEADER_R}"[:col_width - 2], theme.CLR_ACCENT()); y_c3 += 1
                 for n, d in self.character.virtues.items():
                     if y_c3 >= max_draw_y: break
-                    self._display_trait(y_c3, col3_x, n, d, col_width); y_c3 += 1
-                if y_c3 < max_draw_y: self._display_trait(y_c3, col3_x, "Humanity", self.character.humanity, col_width); y_c3 += 1
-                if y_c3 < max_draw_y: self._display_trait(y_c3, col3_x, "Willpower", self.character.willpower, col_width)
+                    self._display_trait(y_c3, col3_x + 2, n, d, col_width - 2); y_c3 += 1
+                if y_c3 < max_draw_y: self._display_trait(y_c3, col3_x + 2, "Humanity", self.character.humanity, col_width - 2); y_c3 += 1
+                if y_c3 < max_draw_y: self._display_trait(y_c3, col3_x + 2, "Willpower", self.character.willpower, col_width - 2)
             
             exit_msg = "Press any key to exit the program..."
             self.stdscr.addstr(start_y + container_height - 2, start_x + (container_width - len(exit_msg)) // 2, exit_msg, theme.CLR_BORDER())

--- a/tui/main_view.py
+++ b/tui/main_view.py
@@ -75,11 +75,11 @@ class MainView:
 
         # --- [Column 2: ABILITIES] ---
         y_c2 = start_y
-        self.stdscr.addstr(y_c2, col2_x, f"{theme.SYM_HEADER_L}ABILITIES{theme.SYM_HEADER_R}"[:col_width], theme.CLR_ACCENT()); y_c2 += 1
+        self.stdscr.addstr(y_c2, col2_x + 2, f"{theme.SYM_HEADER_L}ABILITIES{theme.SYM_HEADER_R}"[:col_width - 2], theme.CLR_ACCENT()); y_c2 += 1
         abilities_shown = [(n, d) for n, d in self.character.abilities.items() if d['new'] > 0]
         for name, data in abilities_shown:
             if y_c2 >= max_y: break
-            self._display_trait(y_c2, col2_x, name, data, col_width); y_c2 += 1
+            self._display_trait(y_c2, col2_x + 2, name, data, col_width - 2); y_c2 += 1
 
         # --- [Column 3: EVERYTHING ELSE] ---
         y_c3 = start_y
@@ -88,20 +88,20 @@ class MainView:
         for cat_name in ["disciplines", "backgrounds"]:
             category = getattr(self.character, cat_name)
             if category and y_c3 < max_y:
-                self.stdscr.addstr(y_c3, col3_x, f"{theme.SYM_HEADER_L}{cat_name.upper()}{theme.SYM_HEADER_R}"[:col_width], theme.CLR_ACCENT()); y_c3 += 1
+                self.stdscr.addstr(y_c3, col3_x + 2, f"{theme.SYM_HEADER_L}{cat_name.upper()}{theme.SYM_HEADER_R}"[:col_width - 2], theme.CLR_ACCENT()); y_c3 += 1
                 for name, data in category.items():
                     if y_c3 >= max_y: break
-                    self._display_trait(y_c3, col3_x, name, data, col_width); y_c3 += 1
+                    self._display_trait(y_c3, col3_x + 2, name, data, col_width - 2); y_c3 += 1
                 y_c3 += 1
         
         # Virtues & Others
         if y_c3 < max_y:
-            self.stdscr.addstr(y_c3, col3_x, f"{theme.SYM_HEADER_L}VIRTUES{theme.SYM_HEADER_R}"[:col_width], theme.CLR_ACCENT()); y_c3 += 1
+            self.stdscr.addstr(y_c3, col3_x + 2, f"{theme.SYM_HEADER_L}VIRTUES{theme.SYM_HEADER_R}"[:col_width - 2], theme.CLR_ACCENT()); y_c3 += 1
             for name, data in self.character.virtues.items():
                 if y_c3 >= max_y: break
-                self._display_trait(y_c3, col3_x, name, data, col_width); y_c3 += 1
-            if y_c3 < max_y: self._display_trait(y_c3, col3_x, "Humanity", self.character.humanity, col_width); y_c3 += 1
-            if y_c3 < max_y: self._display_trait(y_c3, col3_x, "Willpower", self.character.willpower, col_width)
+                self._display_trait(y_c3, col3_x + 2, name, data, col_width - 2); y_c3 += 1
+            if y_c3 < max_y: self._display_trait(y_c3, col3_x + 2, "Humanity", self.character.humanity, col_width - 2); y_c3 += 1
+            if y_c3 < max_y: self._display_trait(y_c3, col3_x + 2, "Willpower", self.character.willpower, col_width - 2)
 
     def _draw_main_menu_screen(self, selected, menu_items):
         h, w = self.stdscr.getmaxyx()


### PR DESCRIPTION
This PR moves the Abilities section to its own column. Now, the main and finalized sheets have three columns, from left to right: Attributes, Abilities, Everything else (Disciplines/Backgrounds/Virtues/Path/Willpower).

## What's changed?
- **Abilities column**:
  - Previously, the Abilities section was *way* too long (and still is) and is located in the same column and below the Attributes section. Sometimes, when the terminal window is too small vertically or if your terminal font is a bit too big. I use kitty with a font size of 14, and the Abilities section did get cut off. So, giving the section its own column hopefully should stop it from being cut off.

## Look 👀
> If it looks a little...yellow-ish is because I'm using a gruvbox theme 😛
<img width="1322" height="914" alt="image" src="https://github.com/user-attachments/assets/f565af11-23e7-4b8b-b053-ecb3ff920880" />
<img width="1315" height="868" alt="image" src="https://github.com/user-attachments/assets/c20734a3-e6b3-474a-92f5-687ca3f76759" />