### PR TITLE
feat: allow input cancelling

### DIFF
--- a/tui/final_view.py
+++ b/tui/final_view.py
@@ -79,7 +79,7 @@ class FinalView:
                 if y_c3 < max_draw_y: self._display_trait(y_c3, col3_x + 2, "Humanity", self.character.humanity, col_width - 2); y_c3 += 1
                 if y_c3 < max_draw_y: self._display_trait(y_c3, col3_x + 2, "Willpower", self.character.willpower, col_width - 2)
             
-            # --- [EXPORT PROMPT IS HERE] ---
+            # --- [EXPORT PROMPT] ---
             controls = "E: Export to Text | Any other key: Exit"
             self.stdscr.addstr(start_y + container_height - 2, start_x + (container_width - len(controls)) // 2, controls, theme.CLR_BORDER())
             self.stdscr.refresh()
@@ -101,7 +101,11 @@ class FinalView:
         self.stdscr.move(prompt_y, 0)
         self.stdscr.clrtoeol()
         
-        filename = utils.get_string_input(self.stdscr, f"Filename (default: {default_name}): ", prompt_y, prompt_x, dummy_redraw)
+        try:
+            # Wrapped in try/except InputCancelled
+            filename = utils.get_string_input(self.stdscr, f"Filename (default: {default_name}): ", prompt_y, prompt_x, dummy_redraw)
+        except utils.InputCancelled:
+            return # Cancel export and go back to sheet loop
         
         if not filename:
             filename = default_name

--- a/tui/utils.py
+++ b/tui/utils.py
@@ -59,6 +59,10 @@ def show_popup(stdscr, title: str, message: str, color_attr=None):
 class QuitApplication(Exception):
     pass
 
+class InputCancelled(Exception):
+    """Used when the user cancels an input (via ESC)"""
+    pass
+
 def get_string_input(stdscr, prompt: str, y: int, x: int, current_screen_func, *args, **kwargs) -> str:
     curses.curs_set(1)
     input_str = ""
@@ -66,15 +70,16 @@ def get_string_input(stdscr, prompt: str, y: int, x: int, current_screen_func, *
 
     while True:
         current_screen_func(*args, **kwargs)
-        stdscr.addstr(y, x, prompt, theme.CLR_ACCENT()) # Prompts are Red
+        stdscr.addstr(y, x, prompt, theme.CLR_ACCENT()) 
         stdscr.addstr(y, input_x_start, " " * 30)
-        stdscr.addstr(y, input_x_start, input_str, theme.CLR_TEXT()) # Input is White
+        stdscr.addstr(y, input_x_start, input_str, theme.CLR_TEXT()) 
         stdscr.move(y, input_x_start + len(input_str))
         stdscr.refresh()
 
         key = stdscr.getch()
 
-        if key == 24: raise QuitApplication()
+        if key == 24: raise QuitApplication() # Ctrl+X
+        elif key == 27: raise InputCancelled() # Esc Key
         elif key in (curses.KEY_ENTER, ord('\n')) and input_str: break
         elif key in (curses.KEY_BACKSPACE, 127, 8): input_str = input_str[:-1]
         elif 32 <= key <= 126 and len(input_str) < 30: input_str += chr(key)


### PR DESCRIPTION
Finally, you can cancel inputs! This applies to everything *except* for mandatory inputs like character setup.

## What's changed?
- Aside from the initial character setup, you can now use `esc` to cancel inputs.
  - For example, if you accidentally select the wrong stat to improve, you can now press `esc` to cancel the improvement. Previously, you *had* to live with your accidental selection 😔

## Next steps
- Following the same vein, the next thing to do would be allowing *refunds* for spent freebie points.