### PR TITLE
fix: set newly added traits (disciplines/backgrounds) to color red

### DIFF
--- a/tui/main_view.py
+++ b/tui/main_view.py
@@ -1,11 +1,10 @@
 # --- [IMPORTS] ---
 import curses
-import textwrap
-from typing import Dict, Any, Optional, List, Tuple
+from typing import List, Tuple
 from . import utils
 from . import theme
-from vtm_npc_logic import VtMCharacter, ATTRIBUTES_LIST, ABILITIES_LIST, VIRTUES_LIST, FREEBIE_COSTS
-from .utils import QuitApplication, InputCancelled
+from vtm_npc_logic import VtMCharacter, ATTRIBUTES_LIST, ABILITIES_LIST, VIRTUES_LIST
+from .utils import QuitApplication
 
 class MainView:
     def __init__(self, stdscr, character: VtMCharacter):
@@ -366,7 +365,8 @@ class MainView:
                 is_modified = False
                 if cat != "System":
                     data = self.character.get_trait_data(cat, name)
-                    if data['base'] != data['new']:
+                    # Traits are red if value changed OR if they are dynamic additions (Disciplines/Backgrounds)
+                    if data['base'] != data['new'] or cat in ["Discipline", "Background"]:
                         is_modified = True
                 
                 style = theme.CLR_ACCENT() if is_modified else theme.CLR_TEXT()


### PR DESCRIPTION
This addresses #24, where newly added traits for Disciplines/Backgrounds were default grey as opposed to red, as it counts as a modification even if it doesn't have any freebie points invested yet.

## What's changed?

- **Red traits**:
  - New Disciplines and Backgrounds that weren't originally in the character setup are now red. That's literally it.

## Look 👀

*These are newly added stats, and they're red! :D*
<img width="381" height="186" alt="image" src="https://github.com/user-attachments/assets/cf253430-7515-4151-91da-acdaaf9cf5d2" />

---

> Closes #17: ties a neat bow on this issue/feature.
> Closes #24