### PR TITLE
refactor: remove Disciplines/Backgrounds entirely from Setup [VNP-7]

### DIFF
--- a/tui/setup_view.py
+++ b/tui/setup_view.py
@@ -146,10 +146,9 @@ class SetupView:
                     character.set_initial_trait(title_text.lower(), item, val)
             return entered_items
 
+        # --- NOTE: Removed the Disciplines and Backgrounds loops ---
         run_setup_loop("Attributes", ATTRIBUTES_LIST, 1, 10)
         run_setup_loop("Abilities", ABILITIES_LIST, 0, 10)
-        run_setup_loop("Disciplines", [], 1, 10, is_freeform=True)
-        run_setup_loop("Backgrounds", [], 1, 10, is_freeform=True)
         
         entered_virtues: Dict[str, Any] = {}
         humanity: Optional[int] = None


### PR DESCRIPTION
Following up from #32, Disciplines and Backgrounds have been removed form Character Setup.

You can only modify Disciplines/Backgrounds on the Character Sheet. Removing it made the setup process faster, since selecting a Clan auto-fills in the Disciplines anyways (and if the user enters their custom Clan, it's likely they'd want to use other/specific Disciplines), and removes the need for implementing Add/Remove Disciplines/Backgrounds in the Setup.

## What's changed?

- Removed the lines from `tui/setup_view.py` that triggered the Discipline/Background setup loops.