### PR TITLE
style: modify Setup text input/selection to match Sheet [VNP-6]

### DIFF
--- a/tui/setup_view.py
+++ b/tui/setup_view.py
@@ -40,7 +40,11 @@ class SetupView:
             utils.draw_box(self.stdscr, start_y, start_x, container_height, container_width, "Character Setup")
             list_y = start_y + 2
             for info_label, info_value in entered_info.items():
-                self.stdscr.addstr(list_y, start_x + 2, f"{info_label}: {info_value}", theme.CLR_ACCENT()); list_y += 1
+                # Label -> RED!
+                self.stdscr.addstr(list_y, start_x + 2, f"{info_label}: ", theme.CLR_ACCENT())
+                # Conf value -> WHITE!
+                self.stdscr.addstr(list_y, start_x + 2 + len(info_label) + 2, f"{info_value}", theme.CLR_TEXT())
+                list_y += 1
             return start_y, start_x, list_y
 
         for label, option_list, min_val, max_val in prompts:
@@ -107,8 +111,12 @@ class SetupView:
                 max_display = container_height - 9
                 start_idx = max(0, len(entered_items) - max_display + 1)
                 for name, value in list(entered_items.items())[start_idx:]:
-                    if list_y >= start_y + container_height - 3: break
-                    self.stdscr.addstr(list_y, start_x + 2, f"{name}: {value}", theme.CLR_ACCENT()); list_y += 1
+                    if list_y >= start_y + container_height - 3: break                        
+                    # Draw label in Red
+                    self.stdscr.addstr(list_y, start_x + 2, f"{name}: ", theme.CLR_ACCENT())
+                    # Draw confirmed value in White
+                    self.stdscr.addstr(list_y, start_x + 2 + len(name) + 2, f"{value}", theme.CLR_TEXT())
+                    list_y += 1
                 if current_item_name:
                     self.stdscr.addstr(list_y, start_x + 2, f"{title_text[:-1]} Name: {current_item_name}", theme.CLR_TEXT())
                 return start_y, start_x, list_y
@@ -162,13 +170,19 @@ class SetupView:
             utils.draw_box(self.stdscr, start_y, start_x, container_height, container_width, "Virtues & Path")
             self.stdscr.addstr(start_y + 2, start_x + 2, "Set initial values (1-10)", theme.CLR_BORDER())
             
-            list_y = start_y + 4
-            for name, value in entered_virtues.items():
-                self.stdscr.addstr(list_y, start_x + 2, f"{name}: {value}", theme.CLR_ACCENT()); list_y += 1
+            list_y = start_y + 4 # Labels -> RED; Conf input -> WHITE
+            for name, value in entered_virtues.items(): # 
+                self.stdscr.addstr(list_y, start_x + 2, f"{name}: ", theme.CLR_ACCENT())
+                self.stdscr.addstr(list_y, start_x + 2 + len(name) + 2, f"{value}", theme.CLR_TEXT())
+                list_y += 1
             if humanity is not None:
-                self.stdscr.addstr(list_y, start_x + 2, f"Humanity/Path: {humanity}", theme.CLR_ACCENT()); list_y += 1
+                self.stdscr.addstr(list_y, start_x + 2, "Humanity/Path: ", theme.CLR_ACCENT())
+                self.stdscr.addstr(list_y, start_x + 2 + len("Humanity/Path: "), f"{humanity}", theme.CLR_TEXT())
+                list_y += 1
             if willpower is not None:
-                self.stdscr.addstr(list_y, start_x + 2, f"Willpower: {willpower}", theme.CLR_ACCENT()); list_y += 1
+                self.stdscr.addstr(list_y, start_x + 2, "Willpower: ", theme.CLR_ACCENT())
+                self.stdscr.addstr(list_y, start_x + 2 + len("Willpower: "), f"{willpower}", theme.CLR_TEXT())
+                list_y += 1
             return start_y, start_x, list_y
 
         for virtue in VIRTUES_LIST:

--- a/tui/utils.py
+++ b/tui/utils.py
@@ -71,7 +71,7 @@ def get_string_input(stdscr, prompt: str, y: int, x: int, current_screen_func, *
         current_screen_func(*args, **kwargs)
         stdscr.addstr(y, x, prompt, theme.CLR_ACCENT()) 
         stdscr.addstr(y, input_x_start, " " * 30)
-        stdscr.addstr(y, input_x_start, input_str, theme.CLR_TEXT()) 
+        stdscr.addstr(y, input_x_start, input_str, theme.CLR_HIGHLIGHT()) # Str input: WHITE -> GOLD (highlight)
         stdscr.move(y, input_x_start + len(input_str))
         stdscr.refresh()
 
@@ -98,7 +98,7 @@ def get_number_input(stdscr, prompt: str, y: int, x: int, min_val: int, max_val:
         show_popup(stdscr, "Invalid Input", "That is not a valid number. Please try again.")
         return None
 
-# --- Hybrid Selection Input ---
+# --- Selection + Manual Input ---
 def get_selection_input(stdscr, prompt: str, y: int, x: int, options: list, current_screen_func, *args, **kwargs) -> str:
     """
     Allows user to select from a list using arrows OR type manually.
@@ -126,7 +126,7 @@ def get_selection_input(stdscr, prompt: str, y: int, x: int, options: list, curr
         # Draw Input Value
         if is_manual:
             curses.curs_set(1)
-            stdscr.addstr(y, input_x_start, manual_buffer, theme.CLR_TEXT())
+            stdscr.addstr(y, input_x_start, manual_buffer, theme.CLR_HIGHLIGHT()) # Manual: WHITE -> GOLD (highlight)
             stdscr.move(y, input_x_start + len(manual_buffer))
         else:
             curses.curs_set(0)


### PR DESCRIPTION
Colors in Setup should now match that of Sheet's.

## What's changed?

- In Setup:
  - Text or values that is currently being inputted is shown in the `HIGHLIGHT` color (*Gold*).
  - Confirmed values are now shown in default `TEXT` color (*White*).
  - Labels remain in the `ACCENT` color (*Red*).

## Look :eyes:

<img width="230" height="147" alt="image" src="https://github.com/user-attachments/assets/b51e9c9b-767b-4d6f-af53-df0aed86d11c" />

---

> Closes #34 - Modified Setup colors to match Sheet.