### PR TITLE
Apply selection menus to Disciplines and Disciplines [VNP-2]

### DIFF
--- a/vtm_npc_logic.py
+++ b/vtm_npc_logic.py
@@ -163,7 +163,7 @@ class VtMCharacter:
         if trait_name not in target_dict:
             return False, "Trait not found."
 
-        # Calculate Refund
+        # Calculate refund (Base + Dots)
         data = target_dict[trait_name]
         # Calculate how many dots were purchased (New - Base). 
         # For added traits, Base is usually 0, so it refunds everything.


### PR DESCRIPTION
Disciplines and Backgrounds in Character Sheet now use the hybrid selection menu!

## What's changed?

- **Selection menu**
  -  For Backgrounds/Disciplines, it should now use the selection menu that Clan uses in Setup.
  - Using the left/right arrow keys will scroll through the list of options (Disciplines/Backgrounds).
  - Entering or clicking on any other key (non-arrow) will lead to manual input.
    - Backspacing/deleting all manually inputted text will return you to the normal selection menu.
  - It should still be all in-line as before. No external textfields.
- **Trait removal**
  - You can now remove traits by highlighting/selecting the trait you want removed and clicking the `DELETE` or `X` key.
    - You will be prompted to confirm your deletion with 
`Y`.
---

> Closes #19 - Added selection menus for Disciplines/Backgrounds