### PR TITLE
fix: keep selection menu UI consistent during manual inputs [VNP-10]

### DIFF
--- a/tui/main_view.py
+++ b/tui/main_view.py
@@ -246,7 +246,7 @@ class MainView:
         
         # Final screen coordinates
         prompt_y = list_start_y + visual_row_index
-        prompt_x = col3_x + 2 
+        prompt_x = col3_x
 
         def redraw_func():
             self._draw_screen(c1, c2, c3)
@@ -388,24 +388,19 @@ class MainView:
             draw_x = start_x + 2
             max_text_w = width - 8
             
+            # --- In-place input rendering ---
             if is_selected:
                 style = theme.CLR_HIGHLIGHT()
-                
-                # --- In-place input rendering ---
-                if self.is_inputting:
-                    # Draw the input box logic: < Poten_ >
-                    # Note: append '_' to show the cursor position clearly
-                    display_str = f"{theme.SYM_SELECTED_L}{self.input_buffer}_{theme.SYM_SELECTED_R}"
+                # Draw the input box logic: < Poten_ >
+                # Note: append '_' to show the cursor position clearly
+                if cat == "System":
+                    text = f"[ {name} ]"
+                    val_str = ""
                 else:
-                    # Standard selected behavior
-                    if cat == "System":
-                        text = f"[ {name} ]"
-                        val_str = ""
-                    else:
-                        data = self.character.get_trait_data(cat, name)
-                        text = name
-                        val_str = f"[{data['new']}]"
-                    display_str = f"{theme.SYM_SELECTED_L}{text:<{max_text_w}}{val_str}{theme.SYM_SELECTED_R}"
+                    data = self.character.get_trait_data(cat, name)
+                    text = name
+                    val_str = f"[{data['new']}]"
+                display_str = f"{theme.SYM_SELECTED_L}{text:<{max_text_w}}{val_str}{theme.SYM_SELECTED_R}"
                 
                 self.stdscr.addstr(start_y + i, draw_x - 2, display_str, style)
             else:

--- a/tui/utils.py
+++ b/tui/utils.py
@@ -117,23 +117,23 @@ def get_selection_input(stdscr, prompt: str, y: int, x: int, options: list, curr
         # Redraw background to prevent trails
         current_screen_func(*args, **kwargs)
         
-        # Draw Prompt
         stdscr.addstr(y, x, prompt, theme.CLR_ACCENT())
         
         # Clear the area where input goes
         stdscr.addstr(y, input_x_start, " " * 40)
         
-        # Draw Input Value
         if is_manual:
             curses.curs_set(1)
-            stdscr.addstr(y, input_x_start, manual_buffer, theme.CLR_HIGHLIGHT()) # Manual: WHITE -> GOLD (highlight)
-            stdscr.move(y, input_x_start + len(manual_buffer))
+            display_str = f"{theme.SYM_SELECTED_L}{manual_buffer}{theme.SYM_SELECTED_R}"
+            stdscr.addstr(y, input_x_start, display_str, theme.CLR_HIGHLIGHT())
+            # Move cursor to immediately after the text, but before the right bracket
+            stdscr.move(y, input_x_start + len(theme.SYM_SELECTED_L) + len(manual_buffer))
         else:
             curses.curs_set(0)
             current_opt = options[selection_index]
             # Draw as < Option >
             display_str = f"{theme.SYM_SELECTED_L}{current_opt}{theme.SYM_SELECTED_R}"
-            stdscr.addstr(y, input_x_start, display_str, theme.CLR_HIGHLIGHT())
+            stdscr.addstr(y, input_x_start, display_str, theme.CLR_HIGHLIGHT())        
 
         stdscr.refresh()
         key = stdscr.getch()


### PR DESCRIPTION
The selection menus in Setup and Sheet are now consistent with each other.

## What's changed?

- **Consistent menu UI**
  - Both Setup (Clan) and Sheet (Backgrounds/Disciplines) now have the same UI.
    - `< ... >` as opposed to the previous (broken) `< ... `
    - When manually entering a value in these menus, the arrow-brackets also remain. See the image below.

<img width="179" height="39" alt="image" src="https://github.com/user-attachments/assets/ef9b5aab-535a-40ff-8c6b-90a336ddba70" />

---

> Closes #38 - Selection menus are now consistent.