### PR TITLE
refactor: renderer outer box and header ownership

### DIFF
--- a/tui/final_view.py
+++ b/tui/final_view.py
@@ -3,7 +3,7 @@ import curses
 from . import utils
 from . import theme
 from vtm_npc_logic import VtMCharacter
-from .renderer import draw_character_sheet_columns
+from .renderer import draw_character_sheet_columns, draw_sheet_container
 
 class FinalView:
     def __init__(self, stdscr, character: VtMCharacter):
@@ -17,32 +17,29 @@ class FinalView:
             h, w = self.stdscr.getmaxyx()
             container_width = min(130, w - 2)
             container_height = min(55, h - 6)
-            start_x, start_y = (w - container_width) // 2, (h - container_height) // 2
-            
-            utils.draw_box(self.stdscr, start_y, start_x, container_height, container_width, "FINAL CHARACTER SHEET")
-            
-            sheet_y, sheet_x = start_y + 2, start_x + 2
-            
-            self.stdscr.addstr(sheet_y, sheet_x, f"{self.character.name} ({self.character.clan})", theme.CLR_TITLE()); sheet_y += 1
-            self.stdscr.addstr(sheet_y, sheet_x, f"Age: {self.character.age} | Gen: {self.character.generation}th | Max: {self.character.max_trait_rating}", theme.CLR_ACCENT()); sheet_y += 1
-            
+
+            # Format freebie string
             if self.character.is_free_mode:
-                spent_str = f"Total Freebie Points Spent: {self.character.spent_freebies}"
-                color = theme.CLR_ACCENT()
+                freebie_str = f"Total Freebie Points Spent: {self.character.spent_freebies}"
+                freebie_color = theme.CLR_ACCENT()
             else:
                 remaining = self.character.total_freebies - self.character.spent_freebies
-                spent_str = f"Freebie Points: {self.character.spent_freebies}/{self.character.total_freebies} spent" + (f" ({remaining} remaining)" if remaining > 0 else "")
-                color = theme.CLR_ACCENT()
-            self.stdscr.addstr(sheet_y, sheet_x, spent_str, color); sheet_y += 2
-            
-            # --- [3-Column Layout] ---
-            col_width = (container_width - 6) // 3
-            cx1 = sheet_x
-            cx2 = sheet_x + col_width + 2
-            cx3 = sheet_x + (col_width * 2) + 4
-            content_y = sheet_y
+                freebie_str = f"Freebie Points: {self.character.spent_freebies}/{self.character.total_freebies} spent"
+                if remaining > 0:
+                    freebie_str += f" ({remaining} remaining)"
+                freebie_color = theme.CLR_ACCENT()
 
-            # Build item lists (same structure as MainView)
+            layout = draw_sheet_container(
+                self.stdscr, self.character,
+                "FINAL CHARACTER SHEET",
+                freebie_str, freebie_color,
+                container_width, container_height
+            )
+
+            layout["start_y"] = layout["content_y"]
+            layout["max_rows"] = container_height - 8
+
+            # Build item lists
             from vtm_npc_logic import ATTRIBUTES_LIST, ABILITIES_LIST, VIRTUES_LIST
 
             col1_items = [("Header", "ATTRIBUTES")] + [("Attribute", a) for a in ATTRIBUTES_LIST]
@@ -65,16 +62,8 @@ class FinalView:
             col3_items.append(("Humanity", "Humanity/Path"))
             col3_items.append(("Willpower", "Willpower"))
 
-            layout = {
-                "start_y":           content_y,
-                "cx1":               cx1,
-                "cx2":               cx2,
-                "cx3":               cx3,
-                "col_width":         col_width,
-                "max_rows":          container_height - 8,
-                "container_height":  container_height,
-                "container_start_y": start_y,
-            }
+            # Remap content_y -> start_y for draw_character_sheet_columns
+            layout["start_y"] = layout["content_y"]
 
             draw_character_sheet_columns(
                 self.stdscr, self.character,
@@ -82,14 +71,15 @@ class FinalView:
                 layout,
                 is_interactive=False
             )
-            
-            # --- [EXPORT PROMPT] ---
+
+            # Export prompt
+            start_y = layout["container_start_y"]
+            start_x = layout["start_x"]
             controls = "E: Export to Text | Any other key: Exit"
             self.stdscr.addstr(start_y + container_height - 2, start_x + (container_width - len(controls)) // 2, controls, theme.CLR_BORDER())
             self.stdscr.refresh()
-            
+
             key = self.stdscr.getch()
-            
             if key == ord('e') or key == ord('E'):
                 self._export_character(start_y + container_height - 2, start_x + 2)
             elif key != curses.KEY_RESIZE:

--- a/tui/main_view.py
+++ b/tui/main_view.py
@@ -5,7 +5,7 @@ from . import utils
 from . import theme
 from vtm_npc_logic import VtMCharacter, ATTRIBUTES_LIST, ABILITIES_LIST, VIRTUES_LIST, FREEBIE_COSTS, DISCIPLINES_LIST, BACKGROUNDS_LIST
 from .utils import QuitApplication
-from .renderer import draw_character_sheet_columns
+from .renderer import draw_character_sheet_columns, draw_sheet_container
 
 class MainView:
     def __init__(self, stdscr, character: VtMCharacter):
@@ -300,43 +300,26 @@ class MainView:
 
         container_width = min(130, w - 2)
         container_height = min(50, h - 2)
-        start_x, start_y = (w - container_width) // 2, (h - container_height) // 2
 
-        utils.draw_box(self.stdscr, start_y, start_x, container_height, container_width, "VTM NPC Progression Tool")
-
-        # Header info
-        header_y = start_y + 1
-        info_str = f"{self.character.name} ({self.character.clan}) | Age: {self.character.age} | Gen: {self.character.generation}th"
-        self.stdscr.addstr(header_y, start_x + 2, info_str, theme.CLR_TITLE())
-
-        # Freebie points
-        header_y += 1
+        # Format freebie string
         if self.character.is_free_mode:
-            spent_str = f"Freebie Points Spent: {self.character.spent_freebies}"
-            color = theme.CLR_ACCENT()
+            freebie_str = f"Freebie Points Spent: {self.character.spent_freebies}"
+            freebie_color = theme.CLR_ACCENT()
         else:
             remaining = self.character.total_freebies - self.character.spent_freebies
-            spent_str = f"Freebie: {remaining}/{self.character.total_freebies}"
-            color = theme.CLR_ACCENT() if remaining > 0 else theme.CLR_ERROR()
-        self.stdscr.addstr(header_y, start_x + 2, spent_str, color)
+            freebie_str = f"Freebie: {remaining}/{self.character.total_freebies}"
+            freebie_color = theme.CLR_ACCENT() if remaining > 0 else theme.CLR_ERROR()
 
-        # Layout calculations
-        col_width = (container_width - 4) // 3
-        cx1 = start_x + 2
-        cx2 = cx1 + col_width + 1
-        cx3 = cx2 + col_width + 1
-        content_y = header_y + 2
+        layout = draw_sheet_container(
+            self.stdscr, self.character,
+            "VTM NPC Progression Tool",
+            freebie_str, freebie_color,
+            container_width, container_height
+        )
 
-        layout = {
-            "start_y":           content_y,
-            "cx1":               cx1,
-            "cx2":               cx2,
-            "cx3":               cx3,
-            "col_width":         col_width,
-            "max_rows":          container_height - 7,
-            "container_height":  container_height,
-            "container_start_y": start_y,
-        }
+        # Remap content_y -> start_y for draw_character_sheet_columns
+        layout["start_y"] = layout["content_y"]
+        layout["max_rows"] = container_height - 7
 
         draw_character_sheet_columns(
             self.stdscr, self.character,
@@ -348,6 +331,8 @@ class MainView:
         )
 
         # Footer
+        start_y = layout["container_start_y"]
+        start_x = layout["start_x"]
         if self.message:
             utils.draw_wrapped_text(self.stdscr, start_y + container_height - 2, start_x + 2, self.message, container_width - 4, self.message_color)
         else:

--- a/tui/main_view.py
+++ b/tui/main_view.py
@@ -197,9 +197,9 @@ class MainView:
             self._add_new_trait(new_cat, c1, c2, c3)
 
     def _add_new_trait(self, category, c1, c2, c3):
+        self.is_inputting = True
         curses.curs_set(1)
-        
-        # Prepare the list (exclude existing traits)
+
         if category == "Discipline":
             options = sorted([d for d in DISCIPLINES_LIST if d not in self.character.disciplines])
         elif category == "Background":
@@ -207,38 +207,39 @@ class MainView:
         else:
             options = []
 
-        # 2. Calculate coordinates for in-line inputs
         h, w = self.stdscr.getmaxyx()
-        
-        # Re-calculate layout (must match _draw_screen logic!!)
         container_width = min(130, w - 2)
         container_height = min(50, h - 2)
-        start_x = (w - container_width) // 2
-        start_y = (h - container_height) // 2
-        
-        col_width = (container_width - 4) // 3
-        # Calculate X for col3
-        col3_x = start_x + 2 + (col_width + 1) * 2
-        
-        # Calculate Y for the Active Row
-        # Logic: Header (1) + Points (1) + Headers (2) + List Start (1) = +5 offset from start_y?
-        # Verify _draw_screen: 
-        # header_y = start_y + 1
-        # content_y = header_y + 2 (so start_y + 3)
-        # list_start_y = content_y + 1 (so start_y + 4)
-        list_start_y = start_y + 4
-        max_rows = container_height - 8
-        
-        # Calculate scroll offset for Col 3
+
+        # Build freebie string (needed to call draw_sheet_container to get accurate layout)
+        if self.character.is_free_mode:
+            freebie_str = f"Freebie Points Spent: {self.character.spent_freebies}"
+            freebie_color = theme.CLR_ACCENT()
+        else:
+            remaining = self.character.total_freebies - self.character.spent_freebies
+            freebie_str = f"Freebie: {remaining}/{self.character.total_freebies}"
+            freebie_color = theme.CLR_ACCENT() if remaining > 0 else theme.CLR_ERROR()
+
+        # Get the same layout dict _draw_screen uses so coordinates match exactly
+        layout = draw_sheet_container(
+            self.stdscr, self.character,
+            "VTM NPC Progression Tool",
+            freebie_str, freebie_color,
+            container_width, container_height
+        )
+        layout["start_y"] = layout["content_y"]
+        layout["max_rows"] = container_height - 7
+
+        list_start_y = layout["content_y"]
+        col3_x = layout["cx3"]
+        max_rows = layout["max_rows"]
+
         scroll_offset = 0
-        if self.active_col == 2: # Column 3
+        if self.active_col == 2:
             if self.active_row >= max_rows:
                 scroll_offset = self.active_row - max_rows + 1
-        
-        # The visual row index (0 to max_rows)
+
         visual_row_index = self.active_row - scroll_offset
-        
-        # Final screen coordinates
         prompt_y = list_start_y + visual_row_index
         prompt_x = col3_x
 
@@ -246,18 +247,15 @@ class MainView:
             self._draw_screen(c1, c2, c3)
 
         try:
-            # Pass prompt="" so it looks like typing is *in* the cell
-            # The get_selection_input will handle the dropdown/typing logic
             name = utils.get_selection_input(self.stdscr, "", prompt_y, prompt_x, options, redraw_func)
-            
             if name:
                 self.character.set_initial_trait(category.lower() + 's', name, 0)
                 self.message = f"Added {name}"
                 self.message_color = theme.CLR_ACCENT()
-                
         except utils.InputCancelled:
             self.message = "Cancelled"
         finally:
+            self.is_inputting = False
             curses.curs_set(0)
 
     def _handle_deletion(self, c1, c2, c3):

--- a/tui/renderer.py
+++ b/tui/renderer.py
@@ -93,6 +93,54 @@ def draw_column(stdscr, start_y: int, start_x: int, width: int, items: list, col
 
         draw_trait_row(stdscr, row_y, start_x + 2, name, data, width, is_selected, is_modified, is_interactive)
 
+# --- [CONTAINER + HEADER] ---
+def draw_sheet_container(stdscr, character, title: str, freebie_str: str, freebie_color, container_width: int, container_height: int) -> dict:
+    """
+    Draws the outer box, character header block, and freebie line.
+    Returns a layout dict ready to pass to draw_character_sheet_columns().
+
+    Caller is responsible for formatting freebie_str and freebie_color.
+    """
+    h, w = stdscr.getmaxyx()
+    start_x = (w - container_width) // 2
+    start_y = (h - container_height) // 2
+
+    utils.draw_box(stdscr, start_y, start_x, container_height, container_width, title)
+
+    # Line 1: Name + Clan
+    header_y = start_y + 1
+    name_str = f"{character.name} ({character.clan})"
+    stdscr.addstr(header_y, start_x + 2, name_str, theme.CLR_TITLE())
+
+    # Line 2: Age + Gen + Max trait
+    header_y += 1
+    meta_str = f"Age: {character.age} | Gen: {character.generation}th | Max: {character.max_trait_rating}"
+    stdscr.addstr(header_y, start_x + 2, meta_str, theme.CLR_ACCENT())
+
+    # Line 3: Freebie points (caller-formatted)
+    header_y += 1
+    stdscr.addstr(header_y, start_x + 2, freebie_str, freebie_color)
+
+    # Layout calculations for the sheet body
+    col_width = (container_width - 4) // 3
+    cx1 = start_x + 2
+    cx2 = cx1 + col_width + 1
+    cx3 = cx2 + col_width + 1
+    content_y = header_y + 2
+
+    return {
+        "start_x":           start_x,
+        "start_y":           start_y,
+        "start_y":           start_y,
+        "content_y":         content_y,
+        "cx1":               cx1,
+        "cx2":               cx2,
+        "cx3":               cx3,
+        "col_width":         col_width,
+        "container_height":  container_height,
+        "container_start_y": start_y,
+    }
+
 # --- [FULL 3-COLUMN SHEET] ---
 def draw_character_sheet_columns(stdscr, character, col1_items: list, col2_items: list, col3_items: list, layout: dict, active_col: int = 0, active_row: int = 0, is_interactive: bool = False):
     """

--- a/tui/renderer.py
+++ b/tui/renderer.py
@@ -8,6 +8,7 @@ Used by both MainView (interactive) and FinalView (static).
 # --- [IMPORTS] ---
 import curses
 from . import theme
+from . import utils
 
 # --- [SINGLE TRAIT ROW] ---
 def draw_trait_row(stdscr, y: int, x: int, name: str, data: dict, width: int, is_selected: bool = False, is_modified: bool = False, is_interactive: bool = False):
@@ -130,7 +131,6 @@ def draw_sheet_container(stdscr, character, title: str, freebie_str: str, freebi
 
     return {
         "start_x":           start_x,
-        "start_y":           start_y,
         "start_y":           start_y,
         "content_y":         content_y,
         "cx1":               cx1,


### PR DESCRIPTION
Extends `tui/renderer.py` with a `draw_sheet_container()` function that owns the outer box, character name/clan, age/gen, and freebie points header block which removes the remaining duplication between `MainView` and `FinalView`.

## What's changed?

- **`tui/renderer.py`**
  - Added `from . import utils` to imports
  - Added `draw_sheet_container()` — draws the outer box and 3-line header block (name/clan, age/gen/max, freebie points); returns a `layout` dict for use by `draw_character_sheet_columns()`
  - Freebie string and color are caller-formatted and passed in, keeping presentation logic out of the renderer
- **`tui/main_view.py`**
  - `_draw_screen()` refactored to call `draw_sheet_container()` and derive layout from its return value
  - `_add_new_trait()` refactored to derive `list_start_y` and `col3_x` from the same `layout` dict, fixing an inline input field offset bug introduced by the new header block height
- **`tui/final_view.py`**
  - `show()` refactored to call `draw_sheet_container()` and derive layout from its return value

---

> Closes #48 - `draw_sheet_container()` added to `tui/renderer.py`; `MainView` and `FinalView` both delegate outer box and header rendering to it.