### PR TITLE
refactor: abstract grid navigation in MainView

### DIFF
--- a/tui/final_view.py
+++ b/tui/final_view.py
@@ -3,7 +3,7 @@ import curses
 from . import utils
 from . import theme
 from vtm_npc_logic import VtMCharacter
-from .renderer import draw_character_sheet_columns, draw_sheet_container
+from .renderer import draw_character_sheet_columns, draw_sheet_container, SheetItem
 
 class FinalView:
     def __init__(self, stdscr, character: VtMCharacter):
@@ -42,25 +42,31 @@ class FinalView:
             # Build item lists
             from vtm_npc_logic import ATTRIBUTES_LIST, ABILITIES_LIST, VIRTUES_LIST
 
-            col1_items = [("Header", "ATTRIBUTES")] + [("Attribute", a) for a in ATTRIBUTES_LIST]
-            col2_items = [("Header", "ABILITIES")] + [("Ability", a) for a in ABILITIES_LIST]
+            col1_items = [SheetItem("Header", "ATTRIBUTES")] + [
+                SheetItem("Attribute", a, self.character.get_trait_data("Attribute", a))
+                for a in ATTRIBUTES_LIST
+            ]
+            col2_items = [SheetItem("Header", "ABILITIES")] + [
+                SheetItem("Ability", a, self.character.get_trait_data("Ability", a))
+                for a in ABILITIES_LIST
+            ]
 
             col3_items = []
-            col3_items.append(("Header", "DISCIPLINES"))
+            col3_items.append(SheetItem("Header", "DISCIPLINES"))
             for disc in self.character.disciplines:
-                col3_items.append(("Discipline", disc))
-            col3_items.append(("Spacer", ""))
-            col3_items.append(("Header", "BACKGROUNDS"))
+                col3_items.append(SheetItem("Discipline", disc, self.character.get_trait_data("Discipline", disc)))
+            col3_items.append(SheetItem("Spacer", ""))
+            col3_items.append(SheetItem("Header", "BACKGROUNDS"))
             for bg in self.character.backgrounds:
-                col3_items.append(("Background", bg))
-            col3_items.append(("Spacer", ""))
-            col3_items.append(("Header", "VIRTUES"))
+                col3_items.append(SheetItem("Background", bg, self.character.get_trait_data("Background", bg)))
+            col3_items.append(SheetItem("Spacer", ""))
+            col3_items.append(SheetItem("Header", "VIRTUES"))
             for virt in VIRTUES_LIST:
-                col3_items.append(("Virtue", virt))
-            col3_items.append(("Spacer", ""))
-            col3_items.append(("Header", "PATH/WILLPOWER"))
-            col3_items.append(("Humanity", "Humanity/Path"))
-            col3_items.append(("Willpower", "Willpower"))
+                col3_items.append(SheetItem("Virtue", virt, self.character.get_trait_data("Virtue", virt)))
+            col3_items.append(SheetItem("Spacer", ""))
+            col3_items.append(SheetItem("Header", "PATH/WILLPOWER"))
+            col3_items.append(SheetItem("Humanity", "Humanity/Path", self.character.get_trait_data("Humanity", "Humanity/Path")))
+            col3_items.append(SheetItem("Willpower", "Willpower", self.character.get_trait_data("Willpower", "Willpower")))
 
             # Remap content_y -> start_y for draw_character_sheet_columns
             layout["start_y"] = layout["content_y"]

--- a/tui/main_view.py
+++ b/tui/main_view.py
@@ -122,35 +122,47 @@ class MainView:
         if 0 <= new_row <= max_idx:
             self.active_row = new_row
 
-    def _get_col1_items(self) -> List[Tuple[str, str]]:
-        return [("Header", "ATTRIBUTES")] + [("Attribute", attr) for attr in ATTRIBUTES_LIST]
+    def _get_col1_items(self) -> list:
+        items = [SheetItem("Header", "ATTRIBUTES")]
+        for attr in ATTRIBUTES_LIST:
+            data = self.character.get_trait_data("Attribute", attr)
+            items.append(SheetItem("Attribute", attr, data))
+        return items
 
-    def _get_col2_items(self) -> List[Tuple[str, str]]:
-        # List ALL abilities so user can buy them from 0
-        return [("Header", "ABILITIES")] + [("Ability", abil) for abil in ABILITIES_LIST]
+    def _get_col2_items(self) -> list:
+        items = [SheetItem("Header", "ABILITIES")]
+        for abil in ABILITIES_LIST:
+            data = self.character.get_trait_data("Ability", abil)
+            items.append(SheetItem("Ability", abil, data))
+        return items
 
-    def _get_col3_items(self) -> List[Tuple[str, str]]:
+    def _get_col3_items(self) -> list:
         items = []
-        
-        # Disciplines
-        items.append(("Header", "DISCIPLINES"))
-        for disc in self.character.disciplines: items.append(("Discipline", disc))
-        items.append(("System", "Add Discipline"))
-        # Backgrounds
-        items.append(("Spacer", ""))
-        items.append(("Header", "BACKGROUNDS"))
-        for bg in self.character.backgrounds: items.append(("Background", bg))
-        items.append(("System", "Add Background"))
-        # Virtues
-        items.append(("Spacer", ""))
-        items.append(("Header", "VIRTUES"))
-        for virt in VIRTUES_LIST: items.append(("Virtue", virt))
-        # Path/Willpower
-        items.append(("Spacer", ""))
-        items.append(("Header", "PATH/WILLPOWER"))
-        items.append(("Humanity", "Humanity/Path"))
-        items.append(("Willpower", "Willpower"))
-        
+
+        items.append(SheetItem("Header", "DISCIPLINES"))
+        for disc in self.character.disciplines:
+            data = self.character.get_trait_data("Discipline", disc)
+            items.append(SheetItem("Discipline", disc, data))
+        items.append(SheetItem("System", "Add Discipline"))
+
+        items.append(SheetItem("Spacer", ""))
+        items.append(SheetItem("Header", "BACKGROUNDS"))
+        for bg in self.character.backgrounds:
+            data = self.character.get_trait_data("Background", bg)
+            items.append(SheetItem("Background", bg, data))
+        items.append(SheetItem("System", "Add Background"))
+
+        items.append(SheetItem("Spacer", ""))
+        items.append(SheetItem("Header", "VIRTUES"))
+        for virt in VIRTUES_LIST:
+            data = self.character.get_trait_data("Virtue", virt)
+            items.append(SheetItem("Virtue", virt, data))
+
+        items.append(SheetItem("Spacer", ""))
+        items.append(SheetItem("Header", "PATH/WILLPOWER"))
+        items.append(SheetItem("Humanity", "Humanity/Path", self.character.get_trait_data("Humanity", "Humanity/Path")))
+        items.append(SheetItem("Willpower", "Willpower", self.character.get_trait_data("Willpower", "Willpower")))
+
         return items
 
     # --- [LOGIC HANDLERS] ---

--- a/tui/main_view.py
+++ b/tui/main_view.py
@@ -146,24 +146,19 @@ class MainView:
 
     # --- [LOGIC HANDLERS] ---
     def _handle_modification(self, c1, c2, c3, delta):
-        """Handles Left/Right arrow keys to modify stats."""
         current_list = [c1, c2, c3][self.active_col]
         item = current_list[self.active_row]
-        
-        # Can't modify "Add New" buttons with arrows
-        if item.category in ["System", "Header", "Spacer"]: 
+
+        if item.category in ("System", "Header", "Spacer"):
             return
 
-        target_val = current_list + delta        
-        # Attempt improvement (logic handles bounds and cost)
+        target_val = item.data['new'] + delta
         success, msg = self.character.improve_trait(item.category, item.name, target_val)
-        
+
         if success:
             self.message = msg
             self.message_color = theme.CLR_ACCENT()
         else:
-            # Show errors (like "Not enough points" or "Min value reached")
-            # For silent bounds checking, check if msg contains "limit" logic
             if "Not enough points" in msg:
                 self.message = msg
                 self.message_color = theme.CLR_ERROR()
@@ -172,22 +167,18 @@ class MainView:
 
     # --- Helper for Number Keys ---
     def _handle_numeric_input(self, c1, c2, c3, value):
-        """Handles pressing keys 0-9 to jump directly to a value."""
         current_list = [c1, c2, c3][self.active_col]
         item = current_list[self.active_row]
-        
-        if category in ["System", "Header", "Spacer"]: 
+
+        if item.category in ("System", "Header", "Spacer"):
             return
 
-        # Attempt to set the trait directly to 'value'
         success, msg = self.character.improve_trait(item.category, item.name, value)
-        
+
         if success:
             self.message = msg
             self.message_color = theme.CLR_ACCENT()
         else:
-            # Sshow errors for bounds (e.g. trying to set 9 when max is 5)
-            # Or cost issues
             self.message = msg
             self.message_color = theme.CLR_ERROR()
 
@@ -265,10 +256,9 @@ class MainView:
         current_list = [c1, c2, c3][self.active_col]
         if not current_list:
             return
-        
+
         item = current_list[self.active_row]
-        
-        # Validation
+
         if item.category not in ("Discipline", "Background"):
             self.message = "Can only remove added Disciplines or Backgrounds."
             self.message_color = theme.CLR_ERROR()
@@ -276,17 +266,14 @@ class MainView:
 
         refund = (item.data['new'] - item.data['base']) * FREEBIE_COSTS.get(item.category, 0)
 
-        # Draw the screen first so the pop-up layers over it properly
         self._draw_screen(c1, c2, c3)
-        # Call the confirmation pop-up
         msg = f"Are you sure you want to completely remove {item.name}?\n\nThis will refund {refund} Freebie Points."
         confirm = utils.show_confirmation_popup(self.stdscr, "Confirm Deletion", msg, theme.CLR_ACCENT())
-        
+
         if confirm:
             success, msg = self.character.remove_trait(item.category, item.name)
             self.message = msg
             self.message_color = theme.CLR_ACCENT()
-            # Move cursor up one to avoid landing on a potentially shifted index or out of bounds
             if self.active_row > 0:
                 self.active_row -= 1
         else:

--- a/tui/main_view.py
+++ b/tui/main_view.py
@@ -37,7 +37,7 @@ class MainView:
             self.active_row = new_row
 
     def run(self):
-        """Main interaction loop using direct navigation."""
+        """Main interaction loop."""
         while True:
             # Build data lists
             col1_items = self._get_col1_items()
@@ -47,40 +47,37 @@ class MainView:
             self.col_counts = [len(col1_items), len(col2_items), len(col3_items)]
             if self.active_row >= self.col_counts[self.active_col]:
                 self.active_row = max(0, self.col_counts[self.active_col] - 1)
-            
-            # INITIAL CHECK: If user somehow landed on a header/spacer, move down
+
+            # Ensure cursor never lands on a Header/Spacer on initial load
             current_list = [col1_items, col2_items, col3_items][self.active_col]
-            if current_list:
-                item_type = current_list[self.active_row][0]
-                if item_type in ["Header", "Spacer"]:
-                    self._move_cursor(1, current_list)
+            if current_list and current_list[self.active_row].category in ("Header", "Spacer"):
+                self.move_selection(1, current_list)
 
             self._draw_screen(col1_items, col2_items, col3_items)
             self.stdscr.refresh()
             key = self.stdscr.getch()
-            
-            if key == 24: return # Ctrl+X
-            elif key == curses.KEY_RESIZE: 
+
+            if key == 24: # Ctrl+X
+                return 
+            elif key == curses.KEY_RESIZE:
                 self.stdscr.erase()
             
             # --- Navigation ---
             elif key == curses.KEY_UP:
                 current_list = [col1_items, col2_items, col3_items][self.active_col]
-                self._move_cursor(-1, current_list)
+                self.move_selection(-1, current_list)
                 self.message = ""
             elif key == curses.KEY_DOWN:
                 current_list = [col1_items, col2_items, col3_items][self.active_col]
-                self._move_cursor(1, current_list)
+                self.move_selection(1, current_list)
                 self.message = ""
-            elif key == ord(' ') or key == 9: # Space or Tab switches columns
+
+            elif key == ord(' ') or key == 9:
                 self.active_col = (self.active_col + 1) % 3
-                self.active_row = 0 # Reset to top of new column
-                # Ensure the user doesn't land on a header after switching
+                self.active_row = 0
                 new_list = [col1_items, col2_items, col3_items][self.active_col]
-                if new_list:
-                    item_type = new_list[0][0]
-                    if item_type in ["Header", "Spacer"]:
-                        self._move_cursor(1, new_list)
+                if new_list and new_list[0].category in ("Header", "Spacer"):
+                    self.move_selection(1, new_list)
                 self.message = ""
             
             # --- Modification ---
@@ -99,29 +96,11 @@ class MainView:
             elif key == curses.KEY_DC or key == ord('x'):
                 self._handle_deletion(col1_items, col2_items, col3_items)
 
-            # --- Special Actions ---
             elif key == ord('\n'):
                 self._handle_enter(col1_items, col2_items, col3_items)
 
     # --- [DATA HELPERS] ---
-    # These generate the lists of (Category, Name) tuples for each column.
-    def _move_cursor(self, delta, items):
-        """Moves cursor, skipping over 'Header' and 'Spacer' items."""
-        new_row = self.active_row + delta
-        max_idx = len(items) - 1
-        
-        # Simple bounds check first
-        if new_row < 0: return
-        if new_row > max_idx: return
-        
-        # Check if target is a Header/Spacer. 
-        while 0 <= new_row <= max_idx and items[new_row][0] in ["Header", "Spacer"]:
-            new_row += delta
-        
-        # Re-check bounds after skipping
-        if 0 <= new_row <= max_idx:
-            self.active_row = new_row
-
+    # These generate the lists of (Category, Name) tuples for each column
     def _get_col1_items(self) -> list:
         items = [SheetItem("Header", "ATTRIBUTES")]
         for attr in ATTRIBUTES_LIST:
@@ -169,18 +148,15 @@ class MainView:
     def _handle_modification(self, c1, c2, c3, delta):
         """Handles Left/Right arrow keys to modify stats."""
         current_list = [c1, c2, c3][self.active_col]
-        category, name = current_list[self.active_row]
+        item = current_list[self.active_row]
         
-         # Can't modify "Add New" buttons with arrows
-        if category in ["System", "Header", "Spacer"]: return
+        # Can't modify "Add New" buttons with arrows
+        if category in ["System", "Header", "Spacer"]: 
+            return
 
-        # Get current data
-        trait_data = self.character.get_trait_data(category, name)
-        current_val = trait_data['new']
-        target_val = current_val + delta
-        
+        target_val = current_val + delta        
         # Attempt improvement (logic handles bounds and cost)
-        success, msg = self.character.improve_trait(category, name, target_val)
+        success, msg = self.character.improve_trait(item.category, item.name, target_val)
         
         if success:
             self.message = msg
@@ -198,12 +174,13 @@ class MainView:
     def _handle_numeric_input(self, c1, c2, c3, value):
         """Handles pressing keys 0-9 to jump directly to a value."""
         current_list = [c1, c2, c3][self.active_col]
-        category, name = current_list[self.active_row]
+        item = current_list[self.active_row]
         
-        if category in ["System", "Header", "Spacer"]: return
+        if category in ["System", "Header", "Spacer"]: 
+            return
 
         # Attempt to set the trait directly to 'value'
-        success, msg = self.character.improve_trait(category, name, value)
+        success, msg = self.character.improve_trait(item.category, item.name, value)
         
         if success:
             self.message = msg
@@ -216,10 +193,10 @@ class MainView:
 
     def _handle_enter(self, c1, c2, c3):
         current_list = [c1, c2, c3][self.active_col]
-        category, name = current_list[self.active_row]
-        
-        if category == "System":
-            new_cat = "Discipline" if "Discipline" in name else "Background"
+        item = current_list[self.active_row]
+
+        if item.category == "System":
+            new_cat = "Discipline" if "Discipline" in item.name else "Background"
             self._add_new_trait(new_cat, c1, c2, c3)
 
     def _add_new_trait(self, category, c1, c2, c3):
@@ -286,33 +263,32 @@ class MainView:
 
     def _handle_deletion(self, c1, c2, c3):
         current_list = [c1, c2, c3][self.active_col]
-        if not current_list: return
+        if not current_list:
+            return
         
-        category, name = current_list[self.active_row]
+        item = current_list[self.active_row]
         
         # Validation
-        if category not in ["Discipline", "Background"] or name == "System" or category in ["Header", "Spacer"]:
+        if item.category not in ("Discipline", "Background"):
             self.message = "Can only remove added Disciplines or Backgrounds."
             self.message_color = theme.CLR_ERROR()
             return
 
-        # Prepare Data
-        trait_data = self.character.get_trait_data(category, name)
-        refund = (trait_data['new'] - trait_data['base']) * FREEBIE_COSTS.get(category, 0)
-        
+        refund = (item.data['new'] - item.data['base']) * FREEBIE_COSTS.get(item.category, 0)
+
         # Draw the screen first so the pop-up layers over it properly
         self._draw_screen(c1, c2, c3)
-        
         # Call the confirmation pop-up
-        msg = f"Are you sure you want to completely remove {name}?\n\nThis will refund {refund} Freebie Points."
+        msg = f"Are you sure you want to completely remove {item.name}?\n\nThis will refund {refund} Freebie Points."
         confirm = utils.show_confirmation_popup(self.stdscr, "Confirm Deletion", msg, theme.CLR_ACCENT())
         
         if confirm:
-            success, msg = self.character.remove_trait(category, name)
+            success, msg = self.character.remove_trait(item.category, item.name)
             self.message = msg
             self.message_color = theme.CLR_ACCENT()
             # Move cursor up one to avoid landing on a potentially shifted index or out of bounds
-            if self.active_row > 0: self.active_row -= 1
+            if self.active_row > 0:
+                self.active_row -= 1
         else:
             self.message = "Deletion cancelled."
             self.message_color = theme.CLR_TEXT()

--- a/tui/main_view.py
+++ b/tui/main_view.py
@@ -151,10 +151,10 @@ class MainView:
         item = current_list[self.active_row]
         
         # Can't modify "Add New" buttons with arrows
-        if category in ["System", "Header", "Spacer"]: 
+        if item.category in ["System", "Header", "Spacer"]: 
             return
 
-        target_val = current_val + delta        
+        target_val = current_list + delta        
         # Attempt improvement (logic handles bounds and cost)
         success, msg = self.character.improve_trait(item.category, item.name, target_val)
         

--- a/tui/main_view.py
+++ b/tui/main_view.py
@@ -5,7 +5,7 @@ from . import utils
 from . import theme
 from vtm_npc_logic import VtMCharacter, ATTRIBUTES_LIST, ABILITIES_LIST, VIRTUES_LIST, FREEBIE_COSTS, DISCIPLINES_LIST, BACKGROUNDS_LIST
 from .utils import QuitApplication
-from .renderer import draw_character_sheet_columns, draw_sheet_container
+from .renderer import draw_character_sheet_columns, draw_sheet_container, SheetItem
 
 class MainView:
     def __init__(self, stdscr, character: VtMCharacter):
@@ -21,6 +21,20 @@ class MainView:
         
         # To track list sizes for boundary checking
         self.col_counts = [0, 0, 0]
+
+    def move_selection(self, delta: int, items: list):
+        """Moves cursor by delta, skipping Header and Spacer items."""
+        new_row = self.active_row + delta
+        max_idx = len(items) - 1
+
+        if new_row < 0 or new_row > max_idx:
+            return
+
+        while 0 <= new_row <= max_idx and items[new_row].category in ("Header", "Spacer"):
+            new_row += delta
+
+        if 0 <= new_row <= max_idx:
+            self.active_row = new_row
 
     def run(self):
         """Main interaction loop using direct navigation."""

--- a/tui/renderer.py
+++ b/tui/renderer.py
@@ -147,25 +147,25 @@ def draw_character_sheet_columns(stdscr, character, col1_items: list, col2_items
 
     layout dict expects:
         {
-            "start_y":          int,  # top of content area
-            "cx1":              int,  # x start of col 1
-            "cx2":              int,  # x start of col 2
-            "cx3":              int,  # x start of col 3
-            "col_width":        int,  # width of each column
-            "max_rows":         int,  # max visible rows
-            "container_height": int,  # full container height
-            "container_start_y":int,  # top of container box
+            "start_y":           int,
+            "cx1":               int,
+            "cx2":               int,
+            "cx3":               int,
+            "col_width":         int,
+            "max_rows":          int,
+            "container_height":  int,
+            "container_start_y": int,
         }
 
-    Resolves trait data from character before passing to draw_column.
+    Items must be pre-resolved SheetItems (carrying their own data).
     """
-    start_y         = layout["start_y"]
-    cx1             = layout["cx1"]
-    cx2             = layout["cx2"]
-    cx3             = layout["cx3"]
-    col_width       = layout["col_width"]
-    max_rows        = layout["max_rows"]
-    container_height = layout["container_height"]
+    start_y          = layout["start_y"]
+    cx1              = layout["cx1"]
+    cx2              = layout["cx2"]
+    cx3              = layout["cx3"]
+    col_width        = layout["col_width"]
+    max_rows         = layout["max_rows"]
+    container_height  = layout["container_height"]
     container_start_y = layout["container_start_y"]
 
     # Draw vertical separators
@@ -175,24 +175,8 @@ def draw_character_sheet_columns(stdscr, character, col1_items: list, col2_items
         stdscr.addstr(i, cx2 - 1, theme.SYM_BORDER_V, theme.CLR_BORDER())
         stdscr.addstr(i, cx3 - 1, theme.SYM_BORDER_V, theme.CLR_BORDER())
 
-    # Resolve data into (cat, name, data) triples
-    def resolve(items):
-        resolved = []
-        for item in items:
-            cat, name = item
-            if cat in ("Header", "Spacer", "System"):
-                resolved.append((cat, name, {}))
-            else:
-                data = character.get_trait_data(cat, name)
-                resolved.append((cat, name, data))
-        return resolved
-
-    r1 = resolve(col1_items)
-    r2 = resolve(col2_items)
-    r3 = resolve(col3_items)
-
     dynamic = ("Discipline", "Background")
 
-    draw_column(stdscr, start_y, cx1, col_width, r1, 0, max_rows, active_col, active_row, is_interactive, dynamic)
-    draw_column(stdscr, start_y, cx2, col_width, r2, 1, max_rows, active_col, active_row, is_interactive, dynamic)
-    draw_column(stdscr, start_y, cx3, col_width, r3, 2, max_rows, active_col, active_row, is_interactive, dynamic)
+    draw_column(stdscr, start_y, cx1, col_width, col1_items, 0, max_rows, active_col, active_row, is_interactive, dynamic)
+    draw_column(stdscr, start_y, cx2, col_width, col2_items, 1, max_rows, active_col, active_row, is_interactive, dynamic)
+    draw_column(stdscr, start_y, cx3, col_width, col3_items, 2, max_rows, active_col, active_row, is_interactive, dynamic)

--- a/tui/renderer.py
+++ b/tui/renderer.py
@@ -58,10 +58,7 @@ def draw_system_row(stdscr, y: int, x: int, name: str, width: int, is_selected: 
 
 # --- [SINGLE COLUMN] ---
 def draw_column(stdscr, start_y: int, start_x: int, width: int, items: list, col_idx: int, max_rows: int, active_col: int, active_row: int, is_interactive: bool = False, dynamic_categories: tuple = ()):
-    """
-    Renders one column of the character sheet.
-    ... [Original docstring remains same] ...
-    """
+    """Renders one column of the character sheet."""
     scroll_offset = 0
     if is_interactive and active_col == col_idx:
         if active_row >= max_rows:
@@ -72,33 +69,29 @@ def draw_column(stdscr, start_y: int, start_x: int, width: int, items: list, col
         if idx >= len(items):
             break
 
-        cat, name = items[idx][0], items[idx][1]
+        item = items[idx]
         row_y = start_y + i
 
-        if cat == "Spacer":
+        if item.category == "Spacer":
             continue
 
-        if cat == "Header":
-            header_text = f"{theme.SYM_HEADER_L}{name}{theme.SYM_HEADER_R}"
+        if item.category == "Header":
+            header_text = f"{theme.SYM_HEADER_L}{item.name}{theme.SYM_HEADER_R}"
             pad = (width - len(header_text)) // 2
             stdscr.addstr(row_y, start_x + max(0, pad), header_text[:width], theme.CLR_BORDER())
             continue
 
         is_selected = is_interactive and (active_col == col_idx) and (active_row == idx)
 
-        if cat == "System":
-            draw_system_row(stdscr, row_y, start_x + 2, name, width, is_selected=is_selected)
+        if item.category == "System":
+            draw_system_row(stdscr, row_y, start_x + 2, item.name, width, is_selected=is_selected)
             continue
 
-        # Data resolution
-        data = items[idx][2] if len(items[idx]) == 3 else {"base": 0, "new": 0}
+        is_modified = item.data['base'] != item.data['new']
+        if is_interactive and item.category in dynamic_categories:
+            is_modified = True
 
-        # Calculate if row should be Red (modified)
-        is_modified = data['base'] != data['new']
-        if is_interactive and cat in dynamic_categories:
-            is_modified = True  # Added categories are always red in interactive mode
-
-        draw_trait_row(stdscr, row_y, start_x + 2, name, data, width, is_selected, is_modified, is_interactive)
+        draw_trait_row(stdscr, row_y, start_x + 2, item.name, item.data, width, is_selected, is_modified, is_interactive)
 
 # --- [CONTAINER + HEADER] ---
 def draw_sheet_container(stdscr, character, title: str, freebie_str: str, freebie_color, container_width: int, container_height: int) -> dict:

--- a/tui/renderer.py
+++ b/tui/renderer.py
@@ -5,10 +5,16 @@ Shared rendering logic for the 3-column character sheet body.
 Used by both MainView (interactive) and FinalView (static).
 """
 
-# --- [IMPORTS] ---
 import curses
 from . import theme
 from . import utils
+from typing import NamedTuple
+
+# --- [SHEET ITEM] ---
+class SheetItem(NamedTuple):
+    category: str
+    name: str
+    data: dict = {}
 
 # --- [SINGLE TRAIT ROW] ---
 def draw_trait_row(stdscr, y: int, x: int, name: str, data: dict, width: int, is_selected: bool = False, is_modified: bool = False, is_interactive: bool = False):


### PR DESCRIPTION
Replaces manual tuple unpacking and scattered nav math in `MainView` with `SheetItem` named tuples and a dedicated `move_selection()` method. Also propagates `SheetItem` to `FinalView` and the renderer, eliminating the old `resolve()` step.

## What's changed?

- **`tui/renderer.py`**
  - Added `SheetItem(category, name, data)` named tuple — shared display primitive for all sheet item lists
  - `draw_column()` simplified — unpacks `SheetItem` attributes directly, no more `len()` checks or index slicing
  - `draw_character_sheet_columns()` simplified — removed `resolve()` entirely since data is now pre-resolved in items
- **`tui/main_view.py`**
  - Added `move_selection(delta, items)`; centralized cursor movement that skips Header/Spacer rows; replaces `_move_cursor()`
  - `_get_col1_items()`, `_get_col2_items()`, `_get_col3_items()` now return `SheetItem` lists with pre-resolved trait data
  - `run()` updated to use `move_selection()` and `.category` / `.name` attribute access throughout
  - `_handle_modification()`, `_handle_numeric_input()`, `_handle_enter()`, `_handle_deletion()` all updated to use `SheetItem` attribute access; no more tuple unpacking
  - `_move_cursor()` deleted; replaced by `move_selection()`
- **`tui/final_view.py`**
  - Item list building in `show()` upgraded to use `SheetItem` with pre-resolved data

---

> Closes #45 - `SheetItem` named tuple introduced in `renderer.py`; `move_selection()` centralizes cursor nav in `MainView`; all handler tuple unpacking replaced with attribute access.