### PR TITLE
feat: save/load JSON characters

### DIFF
--- a/tui/final_view.py
+++ b/tui/final_view.py
@@ -81,13 +81,15 @@ class FinalView:
             # Export prompt
             start_y = layout["container_start_y"]
             start_x = layout["start_x"]
-            controls = "E: Export to Text | Any other key: Exit"
+            controls = "E: Export to Text | S: Save | Any other key: Exit"
             self.stdscr.addstr(start_y + container_height - 2, start_x + (container_width - len(controls)) // 2, controls, theme.CLR_BORDER())
             self.stdscr.refresh()
 
             key = self.stdscr.getch()
             if key == ord('e') or key == ord('E'):
                 self._export_character(start_y + container_height - 2, start_x + 2)
+            elif key == ord('s') or key == ord('S'):
+                self._save_character(start_y + container_height - 2, start_x + 2)
             elif key != curses.KEY_RESIZE:
                 return
 
@@ -119,3 +121,35 @@ class FinalView:
             utils.show_popup(self.stdscr, "Success", f"Character saved to {filename}", theme.CLR_ACCENT())
         except Exception as e:
             utils.show_popup(self.stdscr, "Error", f"Failed to save: {str(e)}", theme.CLR_ERROR())
+
+    def _save_character(self, prompt_y, prompt_x):
+        """Handles the logic for saving character to a JSON file."""
+        from .save_manager import save_character, default_save_name
+
+        def dummy_redraw():
+            pass
+
+        default_name = default_save_name(self.character)
+
+        self.stdscr.move(prompt_y, 0)
+        self.stdscr.clrtoeol()
+
+        try:
+            filename = utils.get_string_input(
+                self.stdscr,
+                f"Save as (default: {default_name}): ",
+                prompt_y, prompt_x,
+                dummy_redraw
+            )
+        except utils.InputCancelled:
+            return
+
+        if not filename:
+            filename = default_name
+
+        success, msg = save_character(self.character, filename)
+
+        if success:
+            utils.show_popup(self.stdscr, "Saved", msg, theme.CLR_ACCENT())
+        else:
+            utils.show_popup(self.stdscr, "Error", msg, theme.CLR_ERROR())

--- a/tui/greeting_view.py
+++ b/tui/greeting_view.py
@@ -1,19 +1,24 @@
-# --- [IMPORTS] ---
 import curses
+from typing import NamedTuple, Optional
 from . import utils
 from . import theme
+from .save_manager import list_saves, load_character, default_save_name
+from vtm_npc_logic import VtMCharacter
+
+# --- [RESULT TYPE] ---
+class GreetingResult(NamedTuple):
+    mode: str  # "default", "free", "load"
+    character: Optional[VtMCharacter] = None
 
 class GreetingView:
     def __init__(self, stdscr):
         self.stdscr = stdscr
 
-    def run(self) -> bool:
+    def run(self) -> GreetingResult:
         """
-        Displays the initial mode selection screen.
-        Returns:
-            bool: True if Free Mode is selected, False for Default Mode.
-        Raises:
-            utils.QuitApplication: If the user presses Ctrl+X.
+        Displays the mode selection screen.
+        Returns a GreetingResult with mode and optionally a loaded character.
+        Raises utils.QuitApplication if the user presses Ctrl+X.
         """
         modes = [
             {
@@ -23,43 +28,92 @@ class GreetingView:
             {
                 "name": "Free Mode",
                 "desc": "Build any character you can imagine. Freebie Points are unlimited, allowing for unrestricted character improvement."
+            },
+            {
+                "name": "Load Character",
+                "desc": "Load a previously saved character from a JSON save file and continue editing."
             }
         ]
         selected = 0
-        
+
         while True:
             h, w = self.stdscr.getmaxyx()
-            self.stdscr.erase() # Changed from clear() to erase()
-            
-            container_width, container_height = 70, 16
+            self.stdscr.erase()
+
+            container_width, container_height = 70, 17
             start_x, start_y = (w - container_width) // 2, (h - container_height) // 2
-            
+
             utils.draw_box(self.stdscr, start_y, start_x, container_height, container_width, "Welcome")
-            
+
             title = "VTM NPC Progression Tool"
             self.stdscr.addstr(start_y + 2, start_x + (container_width - len(title)) // 2, title, theme.CLR_TITLE())
             self.stdscr.addstr(start_y + 4, start_x + 2, "Please select a mode:", theme.CLR_TEXT())
-            
-            # Draw menu options
+
             for i, mode in enumerate(modes):
                 style = theme.CLR_SELECTED() if i == selected else theme.CLR_TEXT()
                 prefix = theme.SYM_POINTER if i == selected else "  "
                 self.stdscr.addstr(start_y + 6 + i, start_x + 4, f"{prefix}{mode['name']}  ", style)
-            
-            desc_box_y = start_y + 9
+
+            desc_box_y = start_y + 10
             self.stdscr.addstr(desc_box_y, start_x + 3, theme.SYM_BORDER_H * (container_width - 6), theme.CLR_BORDER())
-            
             utils.draw_wrapped_text(self.stdscr, desc_box_y + 2, start_x + 4, modes[selected]['desc'], container_width - 8, theme.CLR_ACCENT())
-            
-            # Color is now CLR_ACCENT
+
             controls = "↑/↓: Navigate | Enter: Select | Ctrl+X: Exit"
             self.stdscr.addstr(h - 1, (w - len(controls)) // 2, controls, theme.CLR_ACCENT())
-            
+
             self.stdscr.refresh()
-            
+
             key = self.stdscr.getch()
-            if key == 24: raise utils.QuitApplication()
-            elif key in (curses.KEY_UP, curses.KEY_LEFT): selected = (selected - 1 + len(modes)) % len(modes)
-            elif key in (curses.KEY_DOWN, curses.KEY_RIGHT): selected = (selected + 1) % len(modes)
+            if key == 24:
+                raise utils.QuitApplication()
+            elif key in (curses.KEY_UP, curses.KEY_LEFT):
+                selected = (selected - 1 + len(modes)) % len(modes)
+            elif key in (curses.KEY_DOWN, curses.KEY_RIGHT):
+                selected = (selected + 1) % len(modes)
             elif key in (curses.KEY_ENTER, ord('\n')):
-                return selected == 1
+                if selected == 0:
+                    return GreetingResult(mode="default")
+                elif selected == 1:
+                    return GreetingResult(mode="free")
+                elif selected == 2:
+                    result = self._load_character_flow()
+                    if result is not None:
+                        return result
+                    # If load was cancelled, stay on greeting screen
+
+    def _load_character_flow(self) -> Optional[GreetingResult]:
+        """
+        Handles the load character sub-flow.
+        Returns a GreetingResult on success, or None if cancelled.
+        """
+        saves = list_saves()
+
+        def draw_load_screen():
+            h, w = self.stdscr.getmaxyx()
+            self.stdscr.erase()
+            container_width, container_height = 70, 14
+            start_x, start_y = (w - container_width) // 2, (h - container_height) // 2
+            utils.draw_box(self.stdscr, start_y, start_x, container_height, container_width, "Load Character")
+            if saves:
+                self.stdscr.addstr(start_y + 2, start_x + 2, "Select a save file or type a filename:", theme.CLR_TEXT())
+            else:
+                self.stdscr.addstr(start_y + 2, start_x + 2, "No saves found. Type a filename to load:", theme.CLR_TEXT())
+            return start_y, start_x, start_y + 4
+
+        try:
+            start_y, start_x, input_y = draw_load_screen()
+            filename = utils.get_file_selection_input(
+                self.stdscr, "File: ", input_y, start_x + 2,
+                saves, draw_load_screen
+            )
+        except utils.InputCancelled:
+            return None
+
+        success, result = load_character(filename)
+
+        if success:
+            utils.show_popup(self.stdscr, "Loaded", f"Loaded '{result.name}' successfully!", theme.CLR_ACCENT())
+            return GreetingResult(mode="load", character=result)
+        else:
+            utils.show_popup(self.stdscr, "Error", result, theme.CLR_ERROR())
+            return None

--- a/tui/main_view.py
+++ b/tui/main_view.py
@@ -61,8 +61,6 @@ class MainView:
                 return 
             elif key == curses.KEY_RESIZE:
                 self.stdscr.erase()
-            elif key == 19:  # Ctrl+S
-                self._save_character()
             
             # --- Navigation ---
             elif key == curses.KEY_UP:
@@ -282,41 +280,6 @@ class MainView:
             self.message = "Deletion cancelled."
             self.message_color = theme.CLR_TEXT()
 
-    def _save_character(self):
-        """Handles Ctrl+S quicksave."""
-        from .save_manager import save_character, default_save_name
-
-        h, w = self.stdscr.getmaxyx()
-        container_width = min(130, w - 2)
-        container_height = min(50, h - 2)
-        start_x = (w - container_width) // 2
-        start_y = (h - container_height) // 2
-
-        default_name = default_save_name(self.character)
-
-        try:
-            filename = utils.get_string_input(
-                self.stdscr,
-                f"Save as (default: {default_name}): ",
-                start_y + container_height - 2,
-                start_x + 2,
-                lambda: None
-            )
-        except utils.InputCancelled:
-            return
-
-        if not filename:
-            filename = default_name
-
-        success, msg = save_character(self.character, filename)
-
-        if success:
-            self.message = msg
-            self.message_color = theme.CLR_ACCENT()
-        else:
-            self.message = msg
-            self.message_color = theme.CLR_ERROR()
-
     # --- [DRAWING] ---
     def _draw_screen(self, col1, col2, col3):
         h, w = self.stdscr.getmaxyx()
@@ -360,5 +323,5 @@ class MainView:
         if self.message:
             utils.draw_wrapped_text(self.stdscr, start_y + container_height - 2, start_x + 2, self.message, container_width - 4, self.message_color)
         else:
-            controls = "Arrows/0-9: Modify | Space: Next Col | Enter: Add | Ctrl+S: Save | Ctrl+X: Done"
+            controls = "Arrows/0-9: Modify | Space: Next Col | Enter: Add | Ctrl+X: Done"
             self.stdscr.addstr(start_y + container_height - 2, start_x + (container_width - len(controls)) // 2, controls, theme.CLR_ACCENT())

--- a/tui/main_view.py
+++ b/tui/main_view.py
@@ -61,6 +61,8 @@ class MainView:
                 return 
             elif key == curses.KEY_RESIZE:
                 self.stdscr.erase()
+            elif key == 19:  # Ctrl+S
+                self._save_character()
             
             # --- Navigation ---
             elif key == curses.KEY_UP:
@@ -280,6 +282,41 @@ class MainView:
             self.message = "Deletion cancelled."
             self.message_color = theme.CLR_TEXT()
 
+    def _save_character(self):
+        """Handles Ctrl+S quicksave."""
+        from .save_manager import save_character, default_save_name
+
+        h, w = self.stdscr.getmaxyx()
+        container_width = min(130, w - 2)
+        container_height = min(50, h - 2)
+        start_x = (w - container_width) // 2
+        start_y = (h - container_height) // 2
+
+        default_name = default_save_name(self.character)
+
+        try:
+            filename = utils.get_string_input(
+                self.stdscr,
+                f"Save as (default: {default_name}): ",
+                start_y + container_height - 2,
+                start_x + 2,
+                lambda: None
+            )
+        except utils.InputCancelled:
+            return
+
+        if not filename:
+            filename = default_name
+
+        success, msg = save_character(self.character, filename)
+
+        if success:
+            self.message = msg
+            self.message_color = theme.CLR_ACCENT()
+        else:
+            self.message = msg
+            self.message_color = theme.CLR_ERROR()
+
     # --- [DRAWING] ---
     def _draw_screen(self, col1, col2, col3):
         h, w = self.stdscr.getmaxyx()
@@ -323,5 +360,5 @@ class MainView:
         if self.message:
             utils.draw_wrapped_text(self.stdscr, start_y + container_height - 2, start_x + 2, self.message, container_width - 4, self.message_color)
         else:
-            controls = "Arrows/0-9: Modify | Space: Next Col | Enter: Add/Select | Ctrl+X: Done"
+            controls = "Arrows/0-9: Modify | Space: Next Col | Enter: Add | Ctrl+S: Save | Ctrl+X: Done"
             self.stdscr.addstr(start_y + container_height - 2, start_x + (container_width - len(controls)) // 2, controls, theme.CLR_ACCENT())

--- a/tui/save_manager.py
+++ b/tui/save_manager.py
@@ -1,0 +1,74 @@
+"""
+tui/save_manager.py
+
+Handles all save/load file I/O for VtMCharacter objects.
+Views call these functions directly — no JSON logic leaks into the UI layer.
+"""
+
+import json
+import os
+from vtm_npc_logic import VtMCharacter
+
+# --- [CONSTANTS] ---
+SAVES_DIR = "saves"
+
+# --- [HELPERS] ---
+def _ensure_saves_dir():
+    """Creates the saves/ directory if it doesn't exist."""
+    os.makedirs(SAVES_DIR, exist_ok=True)
+
+def _build_path(filename: str) -> str:
+    """Returns a full path inside saves/ for a given filename."""
+    if not filename.endswith(".json"):
+        filename += ".json"
+    return os.path.join(SAVES_DIR, filename)
+
+# --- [PUBLIC API] ---
+def save_character(character: VtMCharacter, filename: str) -> tuple[bool, str]:
+    """
+    Saves a character to saves/{filename}.json.
+    Returns (success, message).
+    """
+    try:
+        _ensure_saves_dir()
+        path = _build_path(filename)
+        with open(path, 'w') as f:
+            json.dump(character.to_dict(), f, indent=2)
+        return True, f"Character saved to {path}"
+    except Exception as e:
+        return False, f"Failed to save: {str(e)}"
+
+def load_character(filename: str) -> tuple[bool, str | VtMCharacter]:
+    """
+    Loads a character from saves/{filename}.json.
+    Returns (success, VtMCharacter) on success.
+    Returns (False, error_message) on failure.
+    """
+    try:
+        path = _build_path(filename)
+        with open(path, 'r') as f:
+            data = json.load(f)
+        character = VtMCharacter.from_dict(data)
+        return True, character
+    except FileNotFoundError:
+        return False, f"Save file '{filename}' not found."
+    except (json.JSONDecodeError, KeyError) as e:
+        return False, f"Save file is corrupted or invalid: {str(e)}"
+    except Exception as e:
+        return False, f"Failed to load: {str(e)}"
+
+def list_saves() -> list[str]:
+    """
+    Returns a list of save filenames (without extension) found in saves/.
+    Returns an empty list if the directory doesn't exist or is empty.
+    """
+    if not os.path.exists(SAVES_DIR):
+        return []
+    return [
+        f[:-5] for f in os.listdir(SAVES_DIR)
+        if f.endswith(".json")
+    ]
+
+def default_save_name(character: VtMCharacter) -> str:
+    """Returns a sanitized default filename for a character."""
+    return character.name.replace(" ", "_").lower()

--- a/tui/utils.py
+++ b/tui/utils.py
@@ -223,3 +223,13 @@ def safe_input(prompt_fn, *args, **kwargs):
                 return result
         except InputCancelled:
             continue
+
+def get_file_selection_input(stdscr, prompt: str, y: int, x: int, options: list, current_screen_func, *args, **kwargs) -> str:
+    """
+    Wraps get_selection_input with a fallback when no save files exist.
+    If options is empty, falls back to plain get_string_input.
+    """
+    if options:
+        return get_selection_input(stdscr, prompt, y, x, options, current_screen_func, *args, **kwargs)
+    else:
+        return get_string_input(stdscr, prompt, y, x, current_screen_func, *args, **kwargs)

--- a/vtm_npc_tui.py
+++ b/vtm_npc_tui.py
@@ -7,7 +7,6 @@ This module contains the UI for the tool. It handles all rendering and
 user input, and uses on vtm_npc_logic.py for character management.
 """
 
-# --- [IMPORTS] ---
 import curses
 import sys
 import traceback
@@ -36,17 +35,21 @@ class TUIApp:
 
     def run(self):
         """Main application orchestrator."""
-        is_free_mode = False
         try:
             # 0. Greeting
             greeting_view = GreetingView(self.stdscr)
-            is_free_mode = greeting_view.run()
+            result = greeting_view.run()
 
-            # 1. Setup
-            setup_view = SetupView(self.stdscr)
-            self.character = setup_view.run(is_free_mode=is_free_mode)
-            if not self.character:
-                return 
+            if result.mode == "load":
+                # Skip SetupView entirely — character is already built
+                self.character = result.character
+            else:
+                # 1. Setup
+                is_free_mode = result.mode == "free"
+                setup_view = SetupView(self.stdscr)
+                self.character = setup_view.run(is_free_mode=is_free_mode)
+                if not self.character:
+                    return
 
             # 2. Main Interaction
             main_view = MainView(self.stdscr, self.character)
@@ -54,7 +57,7 @@ class TUIApp:
 
         except QuitApplication:
             pass
-        
+
         # 3. Final Display
         if self.character:
             final_view = FinalView(self.stdscr, self.character)


### PR DESCRIPTION
Wires up the serialization groundwork from #44 into a full save/load feature. Characters can now be saved to and loaded from JSON files.

## What's changed?
- **`tui/save_manager.py` (new file)**
  - `save_character()`: writes character state to `saves/{filename}.json`, auto-creating the directory
  - `load_character()`: reads and deserializes a character from a save file, with error handling for missing/corrupted files
  - `list_saves()`: returns available save filenames for the load picker
  - `default_save_name()`: produces a sanitized default filename from the character's name
- **`tui/utils.py`**
  - Added `get_file_selection_input()`: wraps `get_selection_input()` with a fallback to plain text input when no save files exist
- **`tui/greeting_view.py`**
  - Added `GreetingResult(mode, character)` named tuple and replaces the previous `bool` return so the orchestrator can branch on mode and receive a loaded character
  - Added "Load Character" as a third mode option
  - Added `_load_character_flow()`: handles the file picker sub-screen; returns to greeting on cancel or error
- **`vtm_npc_tui.py`**
  - `TUIApp.run()` updated to read `GreetingResult.mode`: skips `SetupView` entirely when loading, branches to `MainView` directly with the restored character
- **`tui/final_view.py`**
  - Added `S` keybind for saving alongside the existing `E` export
  - Added `_save_character()` method: prompts for filename, defaults to character name, calls `save_manager.save_character()`

### Notes
- Quicksave (Ctrl+S in MainView) was explored and cut.
- Save files are stored in `saves/` relative to the project root

---

> Closes #53 - save/load implemented via `tui/save_manager.py`; `GreetingView` supports loading saved characters; `FinalView` supports saving.