### PR TITLE
fix: add trait deletion keybind missing from footer controls

### DIFF
--- a/tui/main_view.py
+++ b/tui/main_view.py
@@ -323,5 +323,5 @@ class MainView:
         if self.message:
             utils.draw_wrapped_text(self.stdscr, start_y + container_height - 2, start_x + 2, self.message, container_width - 4, self.message_color)
         else:
-            controls = "Arrows/0-9: Modify | Space: Next Col | Enter: Add | Ctrl+X: Done"
+            controls = "Arrows/0-9: Modify | Space: Next Col | Enter: Add | X: Delete Trait | Ctrl+X: Done"
             self.stdscr.addstr(start_y + container_height - 2, start_x + (container_width - len(controls)) // 2, controls, theme.CLR_ACCENT())


### PR DESCRIPTION
The `x` key for deleting Disciplines and Backgrounds was undocumented in the footer.

## What's changed?

- **`tui/main_view.py`**
  - Updated controls string in `_draw_screen()` to include `X: Delete`

<img width="776" height="55" alt="image" src="https://github.com/user-attachments/assets/b221c168-d332-4d7f-bfb0-7c36a232cafe" />

---

> Closes #58 - `X: Delete Trait` added to the footer controls bar in `MainView`.