### PR TITLE
fix: remove underline from header and added version display

### DIFF
--- a/tui/greeting_view.py
+++ b/tui/greeting_view.py
@@ -5,6 +5,9 @@ from . import theme
 from .save_manager import list_saves, load_character, default_save_name
 from vtm_npc_logic import VtMCharacter
 
+# --- [VERSION] ---
+VERSION = "v2.4.2"
+
 # --- [RESULT TYPE] ---
 class GreetingResult(NamedTuple):
     mode: str  # "default", "free", "load"
@@ -45,7 +48,7 @@ class GreetingView:
 
             utils.draw_box(self.stdscr, start_y, start_x, container_height, container_width, "Welcome")
 
-            title = "VTM NPC Progression Tool"
+            title = f"VTM NPC Progression Tool {VERSION}"
             self.stdscr.addstr(start_y + 2, start_x + (container_width - len(title)) // 2, title, theme.CLR_TITLE())
             self.stdscr.addstr(start_y + 4, start_x + 2, "Please select a mode:", theme.CLR_TEXT())
 

--- a/tui/theme.py
+++ b/tui/theme.py
@@ -72,7 +72,7 @@ def CLR_BORDER():
 
 def CLR_TITLE():
     """Headings/Titles (Bold Red)"""
-    return curses.color_pair(_ID_ACCENT) | curses.A_BOLD | curses.A_UNDERLINE
+    return curses.color_pair(_ID_ACCENT) | curses.A_BOLD
 
 def CLR_SELECTED():
     """Selected Menu Items (Inverse Red)"""

--- a/vtm_npc_tui.py
+++ b/vtm_npc_tui.py
@@ -15,7 +15,7 @@ from tui.greeting_view import GreetingView
 from tui.setup_view import SetupView
 from tui.main_view import MainView
 from tui.final_view import FinalView
-from tui import theme # Theme import here!
+from tui import theme
 
 # --- [TUI ORCHESTRATOR] ---
 class TUIApp:


### PR DESCRIPTION
Removes the hard-to-read underline from title text and adds a version number to the greeting screen.

## What's changed?

- **`tui/theme.py`**
  - Removed `A_UNDERLINE` from `CLR_TITLE()`. Bold red alone is cleaner and more readable in the TUI

- **`tui/greeting_view.py`**
  - Added `VERSION` constant
  - Version number appended to the app title on the greeting screen

---

> Closes #60 - underline removed from `CLR_TITLE()`, version displayed in `GreetingView`